### PR TITLE
Feature/user

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -30,10 +30,14 @@ import { GetScreenshotVerificationsResponseDto } from './dto/get-screenshot-veri
 import { checkPossibleResponseDto } from 'src/user/dto/check-possible-response.dto';
 import { Response } from 'express';
 import { SignUpResponseDto } from './dto/sign-up-response.dto';
+import { UserService } from 'src/user/user.service';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(
+    private readonly authService: AuthService,
+    private readonly userService: UserService,
+  ) {}
 
   @UseGuards(LocalAuthGuard)
   @Post('login')
@@ -102,6 +106,28 @@ export class AuthController {
   ): Promise<checkPossibleResponseDto> {
     const responseDto =
       await this.authService.checkStudentNumberPossible(studentNumber);
+    const code = responseDto.possible ? 200 : 403;
+    res.status(code);
+    return responseDto;
+  }
+
+  @Post('username/:username')
+  async checkUsernamePossible(
+    @Param('username') username: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<checkPossibleResponseDto> {
+    const responseDto = await this.userService.checkUsernamePossible(username);
+    const code = responseDto.possible ? 200 : 403;
+    res.status(code);
+    return responseDto;
+  }
+
+  @Post('email/:email')
+  async checkEmailPossible(
+    @Param('email') email: string,
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<checkPossibleResponseDto> {
+    const responseDto = await this.userService.checkEmailPossible(email);
     const code = responseDto.possible ? 200 : 403;
     res.status(code);
     return responseDto;

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -21,7 +21,7 @@ import { VerificationResponseDto } from './dto/verification-response.dto';
 import { VerifyEmailResponseDto } from './dto/verify-email-response.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { ScreenshotVerificationRequestDto } from './dto/screenshot-verification-request.dto';
+import { SignUpRequestDto } from './dto/sign-up-request.dto';
 ('./guards/jwt-auth.guard');
 import { AdminAuthGuard } from './guards/admin-auth.guard';
 import { VerifyScreenshotRequestDto } from './dto/verify-screenshot-request.dto';
@@ -29,6 +29,7 @@ import { VerifyScreenshotResponseDto } from './dto/verify-screenshot-response.dt
 import { GetScreenshotVerificationsResponseDto } from './dto/get-screenshot-verifications-request.dto';
 import { checkPossibleResponseDto } from 'src/user/dto/check-possible-response.dto';
 import { Response } from 'express';
+import { SignUpResponseDto } from './dto/sign-up-response.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -66,8 +67,8 @@ export class AuthController {
   @UseInterceptors(FileInterceptor('screenshot'))
   async createUserandScreenshotRequest(
     @UploadedFile() screenshot: Express.Multer.File,
-    @Body() body: ScreenshotVerificationRequestDto,
-  ): Promise<VerificationResponseDto> {
+    @Body() body: SignUpRequestDto,
+  ): Promise<SignUpResponseDto> {
     if (!screenshot) {
       throw new BadRequestException('screenshot should be uploaded');
     }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -95,7 +95,7 @@ export class AuthController {
     return await this.authService.verifyScreenshotReqeust(id, body.verify);
   }
 
-  @Post('studentNumber/:studentNumber')
+  @Post('student-number/:studentNumber')
   async checkStudentNumberPossible(
     @Param('studentNumber') studentNumber: number,
     @Res({ passthrough: true }) res: Response,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -19,14 +19,14 @@ import { VerificationResponseDto } from './dto/verification-response.dto';
 import { VerifyEmailResponseDto } from './dto/verify-email-response.dto';
 import { LoginResponseDto } from './dto/login-response.dto';
 import { KuVerificationRepository } from './ku-verification.repository';
-import { ScreenshotVerificationResponseDto } from './dto/screenshot-verification-response.dto';
+import { SignUpResponseDto } from './dto/sign-up-response.dto';
 import { ConfigService } from '@nestjs/config';
 import { VerifyScreenshotResponseDto } from './dto/verify-screenshot-response.dto';
 import { GetScreenshotVerificationsResponseDto } from './dto/get-screenshot-verifications-request.dto';
 import { FileService } from './file.service';
 import { UserService } from 'src/user/user.service';
 import { checkPossibleResponseDto } from 'src/user/dto/check-possible-response.dto';
-import { ScreenshotVerificationRequestDto } from './dto/screenshot-verification-request.dto';
+import { SignUpRequestDto } from './dto/sign-up-request.dto';
 
 @Injectable()
 export class AuthService {
@@ -171,8 +171,8 @@ export class AuthService {
 
   async createUserandScreenshotRequest(
     screenshot: Express.Multer.File,
-    requestDto: ScreenshotVerificationRequestDto,
-  ): Promise<VerificationResponseDto> {
+    requestDto: SignUpRequestDto,
+  ): Promise<SignUpResponseDto> {
     //유저생성
     const user = await this.userService.createUser({
       email: requestDto.email,
@@ -195,7 +195,7 @@ export class AuthService {
       user,
     );
 
-    return new ScreenshotVerificationResponseDto(true, studentNumber);
+    return new SignUpResponseDto(true, studentNumber);
   }
 
   validateAdmin(id: string, password: string): boolean {

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -25,6 +25,8 @@ import { VerifyScreenshotResponseDto } from './dto/verify-screenshot-response.dt
 import { GetScreenshotVerificationsResponseDto } from './dto/get-screenshot-verifications-request.dto';
 import { FileService } from './file.service';
 import { UserService } from 'src/user/user.service';
+import { checkPossibleResponseDto } from 'src/user/dto/check-possible-response.dto';
+import { ScreenshotVerificationRequestDto } from './dto/screenshot-verification-request.dto';
 
 @Injectable()
 export class AuthService {
@@ -149,12 +151,9 @@ export class AuthService {
     return Math.floor(Math.random() * (maxm - minm + 1)) + minm;
   }
 
-  async createScreenshotRequest(
-    screenshot: Express.Multer.File,
+  async checkStudentNumberPossible(
     studentNumber: number,
-    userId: number,
-  ): Promise<VerificationResponseDto> {
-    //이미 등록된 학번인지 확인
+  ): Promise<checkPossibleResponseDto> {
     const requests =
       await this.kuVerificationRepository.findRequestsByStudentNumber(
         studentNumber,
@@ -162,36 +161,26 @@ export class AuthService {
     if (requests) {
       for (const request of requests) {
         if (request.user.isVerified) {
-          throw new BadRequestException('student number already exists!');
+          return new checkPossibleResponseDto(false);
         }
       }
     }
 
-    //이미 요청을 보냈던 유저인지 확인(그렇다면 원래 요청 수정)
-    const user = await this.userService.findUserById(userId);
-    const userRequest =
-      await this.kuVerificationRepository.findRequestByUser(user);
-    if (userRequest) {
-      await this.fileService.deleteFile(userRequest.imgDir);
+    return new checkPossibleResponseDto(true);
+  }
 
-      const filename = await this.fileService.uploadFile(
-        screenshot,
-        'KuVerification',
-        'screenshot',
-      );
+  async createUserandScreenshotRequest(
+    screenshot: Express.Multer.File,
+    requestDto: ScreenshotVerificationRequestDto,
+  ): Promise<VerificationResponseDto> {
+    //유저생성
+    const user = await this.userService.createUser({
+      email: requestDto.email,
+      password: requestDto.password,
+      username: requestDto.username,
+    });
 
-      const isModified =
-        await this.kuVerificationRepository.modifyVerificationRequest(
-          userRequest,
-          filename,
-          studentNumber,
-          user,
-        );
-      if (!isModified) {
-        throw new NotImplementedException('verify request failed!');
-      }
-      return new ScreenshotVerificationResponseDto(true, studentNumber);
-    }
+    const studentNumber = requestDto.studentNumber;
 
     //요청 생성
     const filename = await this.fileService.uploadFile(

--- a/src/auth/dto/screenshot-verification-request.dto.ts
+++ b/src/auth/dto/screenshot-verification-request.dto.ts
@@ -1,6 +1,7 @@
 import { IsNotEmpty, IsNumber } from 'class-validator';
+import { CreateUserRequestDto } from 'src/user/dto/create-user-request.dto';
 
-export class ScreenshotVerificationRequestDto {
+export class ScreenshotVerificationRequestDto extends CreateUserRequestDto {
   @IsNotEmpty()
   @IsNumber()
   studentNumber: number;

--- a/src/auth/dto/sign-up-request.dto.ts
+++ b/src/auth/dto/sign-up-request.dto.ts
@@ -1,7 +1,7 @@
 import { IsNotEmpty, IsNumber } from 'class-validator';
 import { CreateUserRequestDto } from 'src/user/dto/create-user-request.dto';
 
-export class ScreenshotVerificationRequestDto extends CreateUserRequestDto {
+export class SignUpRequestDto extends CreateUserRequestDto {
   @IsNotEmpty()
   @IsNumber()
   studentNumber: number;

--- a/src/auth/dto/sign-up-response.dto.ts
+++ b/src/auth/dto/sign-up-response.dto.ts
@@ -1,4 +1,4 @@
-export class ScreenshotVerificationResponseDto {
+export class SignUpResponseDto {
   constructor(sended: boolean, studentNumber: number) {
     this.sended = sended;
     this.studentNumber = studentNumber;

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,48 +1,15 @@
-import {
-  Body,
-  Controller,
-  Get,
-  Param,
-  Patch,
-  Post,
-  Res,
-  UseGuards,
-} from '@nestjs/common';
+import { Body, Controller, Get, Patch, UseGuards } from '@nestjs/common';
 import { UserService } from './user.service';
-import { checkPossibleResponseDto } from './dto/check-possible-response.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { User } from 'src/decorators/user.decorator';
 import { AuthorizedUserDto } from 'src/auth/dto/authorized-user-dto';
 import { SetProfileResponseDto } from './dto/set-profile-response.dto';
 import { SetProfileRequestDto } from './dto/set-profile-request.dto';
 import { GetProfileResponseDto } from './dto/get-profile-response.dto';
-import { Response } from 'express';
 
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
-
-  @Post('username/:username')
-  async checkUsernamePossible(
-    @Param('username') username: string,
-    @Res({ passthrough: true }) res: Response,
-  ): Promise<checkPossibleResponseDto> {
-    const responseDto = await this.userService.checkUsernamePossible(username);
-    const code = responseDto.possible ? 200 : 403;
-    res.status(code);
-    return responseDto;
-  }
-
-  @Post('email/:email')
-  async checkEmailPossible(
-    @Param('email') email: string,
-    @Res({ passthrough: true }) res: Response,
-  ): Promise<checkPossibleResponseDto> {
-    const responseDto = await this.userService.checkEmailPossible(email);
-    const code = responseDto.possible ? 200 : 403;
-    res.status(code);
-    return responseDto;
-  }
 
   @UseGuards(JwtAuthGuard)
   @Patch('/profile')

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -9,9 +9,7 @@ import {
   UseGuards,
 } from '@nestjs/common';
 import { UserService } from './user.service';
-import { CreateUserRequestDto } from './dto/create-user-request.dto';
 import { checkPossibleResponseDto } from './dto/check-possible-response.dto';
-import { CreateUserResponseDto } from './dto/create-user-response.dto';
 import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { User } from 'src/decorators/user.decorator';
 import { AuthorizedUserDto } from 'src/auth/dto/authorized-user-dto';
@@ -23,13 +21,6 @@ import { Response } from 'express';
 @Controller('user')
 export class UserController {
   constructor(private readonly userService: UserService) {}
-
-  @Post()
-  async register(
-    @Body() createUserDto: CreateUserRequestDto,
-  ): Promise<CreateUserResponseDto> {
-    return await this.userService.createUser(createUserDto);
-  }
 
   @Post('username/:username')
   async checkUsernamePossible(

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -8,7 +8,6 @@ import { UserRepository } from './user.repository';
 import { CreateUserRequestDto } from './dto/create-user-request.dto';
 import { hash } from 'bcrypt';
 import { checkPossibleResponseDto } from './dto/check-possible-response.dto';
-import { CreateUserResponseDto } from './dto/create-user-response.dto';
 import { SetProfileResponseDto } from './dto/set-profile-response.dto';
 import { GetProfileResponseDto } from './dto/get-profile-response.dto';
 import { SetProfileRequestDto } from './dto/set-profile-request.dto';
@@ -21,9 +20,7 @@ export class UserService {
     private readonly userRepository: UserRepository,
   ) {}
 
-  async createUser(
-    createUserDto: CreateUserRequestDto,
-  ): Promise<CreateUserResponseDto> {
+  async createUser(createUserDto: CreateUserRequestDto): Promise<UserEntity> {
     const userByEmail = await this.userRepository.findUserByEmail(
       createUserDto.email,
     );
@@ -40,12 +37,10 @@ export class UserService {
 
     const hashedPassword = await hash(createUserDto.password, 10);
 
-    await this.userRepository.createUser({
+    return await this.userRepository.createUser({
       ...createUserDto,
       password: hashedPassword,
     });
-
-    return new CreateUserResponseDto(true);
   }
 
   async checkUsernamePossible(


### PR DESCRIPTION
## 📝 Description
- 회원가입과 학교인증요청 api 통합
- 학번 중복확인 api 추가

## ✨ To Discuss
- 회원가입요청 보냈을때 응답 형태에 관한 논의
추가로 email, username 중복확인 url 은 유저 정보 관련 부분으로 /user로 시작하는데
학번은 인증 관련 부분으로 따로 관리되어서 중복확인 url 이 /auth 로 시작해서
통일성을 해치는게 아닐까 하는 생각이 들어 이게 올바른 api url 형태인지 논의되면 좋을 듯 합니다.

## 🧪 Test
노션에 정리된 api 명세서 대로 잘 동작하는지(특히 회원가입 및 학교인증요청 api)

## 🎸 ETC
회원가입에 사용되는 url 순서대로 명세서에 정리해 두어서 하나씩 순서대로 테스트해주시면 감사하겠습니다.
admin 관련 기능들은 admin 사이트에서 요청 목록이 뜨고 수락/거절이 잘 동작하는지 까지도 확인되면 좋을 것 같습니다.
