### PR TITLE
Feature/user

### DIFF
--- a/src/entities/club-like.entity.ts
+++ b/src/entities/club-like.entity.ts
@@ -22,7 +22,7 @@ export class ClubLikeEntity extends CommonEntity {
   club: ClubEntity;
 
   @ManyToOne(() => UserEntity, (user) => user.clubLikes, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
   })
   @JoinColumn({ name: 'userId' })
   user: UserEntity;

--- a/src/entities/comment-like.entity.ts
+++ b/src/entities/comment-like.entity.ts
@@ -14,7 +14,7 @@ export class CommentLikeEntity extends CommonEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   userId: number;
 
   @Column({ nullable: false })
@@ -22,7 +22,7 @@ export class CommentLikeEntity extends CommonEntity {
 
   @JoinColumn({ name: 'userId' })
   @ManyToOne(() => UserEntity, (userEntity) => userEntity.commentLikes, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
   })
   user: UserEntity;
 

--- a/src/entities/comment.entity.ts
+++ b/src/entities/comment.entity.ts
@@ -17,7 +17,7 @@ export class CommentEntity extends CommonEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   userId: number;
 
   @Column({ nullable: false })
@@ -37,7 +37,7 @@ export class CommentEntity extends CommonEntity {
 
   @JoinColumn({ name: 'userId' })
   @ManyToOne(() => UserEntity, (userEntity) => userEntity.comments, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
   })
   user: UserEntity;
 

--- a/src/entities/course-review-recommend.entity.ts
+++ b/src/entities/course-review-recommend.entity.ts
@@ -16,7 +16,7 @@ export class CourseReviewRecommendEntity extends CommonEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   userId: number;
 
   @Column({ nullable: false })
@@ -24,7 +24,7 @@ export class CourseReviewRecommendEntity extends CommonEntity {
 
   @JoinColumn({ name: 'userId' })
   @ManyToOne(() => UserEntity, (user) => user.courseReviewRecommends, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
   })
   user: UserEntity;
 

--- a/src/entities/course-review.entity.ts
+++ b/src/entities/course-review.entity.ts
@@ -15,7 +15,7 @@ export class CourseReviewEntity extends CommonEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   userId: number;
 
   @Column('int', { nullable: false })
@@ -56,7 +56,7 @@ export class CourseReviewEntity extends CommonEntity {
 
   @JoinColumn({ name: 'userId' })
   @ManyToOne(() => UserEntity, (user) => user.courseReviews, {
-    nullable: false,
+    onDelete: 'SET NULL',
   })
   user: UserEntity;
 

--- a/src/entities/notice.entity.ts
+++ b/src/entities/notice.entity.ts
@@ -13,7 +13,7 @@ export class NoticeEntity extends CommonEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   userId: number;
 
   @Column('varchar', { nullable: false })

--- a/src/entities/post-reaction.entity.ts
+++ b/src/entities/post-reaction.entity.ts
@@ -14,7 +14,7 @@ export class PostReactionEntity extends CommonEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   userId: number;
 
   @Column({ nullable: false })
@@ -25,7 +25,7 @@ export class PostReactionEntity extends CommonEntity {
 
   @JoinColumn({ name: 'userId' })
   @ManyToOne(() => UserEntity, (userEntity) => userEntity.postScraps, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
   })
   user: UserEntity;
 

--- a/src/entities/post-scrap.entity.ts
+++ b/src/entities/post-scrap.entity.ts
@@ -14,7 +14,7 @@ export class PostScrapEntity extends CommonEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   userId: number;
 
   @Column({ nullable: false })
@@ -22,7 +22,7 @@ export class PostScrapEntity extends CommonEntity {
 
   @JoinColumn({ name: 'userId' })
   @ManyToOne(() => UserEntity, (userEntity) => userEntity.postScraps, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
   })
   user: UserEntity;
 

--- a/src/entities/post.entity.ts
+++ b/src/entities/post.entity.ts
@@ -21,7 +21,7 @@ export class PostEntity extends CommonEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   userId: number;
 
   @Column({ nullable: false })
@@ -65,7 +65,7 @@ export class PostEntity extends CommonEntity {
 
   @JoinColumn({ name: 'userId' })
   @ManyToOne(() => UserEntity, (userEntity) => userEntity.posts, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
   })
   user: UserEntity;
 

--- a/src/entities/report.entity.ts
+++ b/src/entities/report.entity.ts
@@ -15,7 +15,7 @@ export class ReportEntity extends CommonEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;
 
-  @Column({ nullable: false })
+  @Column({ nullable: true })
   reporterId: number;
 
   @Column({ nullable: false })
@@ -29,7 +29,7 @@ export class ReportEntity extends CommonEntity {
 
   @JoinColumn({ name: 'reporterId' })
   @ManyToOne(() => UserEntity, (userEntity) => userEntity.reports, {
-    onDelete: 'CASCADE',
+    onDelete: 'SET NULL',
   })
   user: UserEntity;
 

--- a/src/home/club/club.service.ts
+++ b/src/home/club/club.service.ts
@@ -39,10 +39,10 @@ export class ClubService {
       return [];
     }
 
-    // 현재 접속 중인 유저의 각 동아리에 대한 찜 여부 함께 반환. 유저 존재하지 않을 시 false
+    // 현재 접속 중인 유저의 각 동아리에 대한 좋아요 여부 함께 반환. 유저 존재하지 않을 시 false
     let clubList = clubs.map((club) => {
       const isLiked = club.clubLikes.some((clubLike) =>
-        user ? clubLike.user.id === user.id : false,
+        user && clubLike.user ? clubLike.user.id === user.id : false,
       );
       return new GetClubResponseDto(club, isLiked);
     });

--- a/src/user/user.repository.ts
+++ b/src/user/user.repository.ts
@@ -53,6 +53,14 @@ export class UserRepository extends Repository<UserEntity> {
     return user;
   }
 
+  async findUserByEmailWithDeleted(email: string): Promise<UserEntity> {
+    const user = await this.findOne({
+      where: { email: email },
+      withDeleted: true,
+    });
+    return user;
+  }
+
   async findUserById(id: number): Promise<UserEntity> {
     const user = await this.findOne({
       where: { id: id },
@@ -63,6 +71,14 @@ export class UserRepository extends Repository<UserEntity> {
   async findUserByUsername(username: string): Promise<UserEntity> {
     const user = await this.findOne({
       where: { username: username },
+    });
+    return user;
+  }
+
+  async findUserByUsernameWithDeleted(username: string): Promise<UserEntity> {
+    const user = await this.findOne({
+      where: { username: username },
+      withDeleted: true,
     });
     return user;
   }


### PR DESCRIPTION
## 📝 Description
회원가입 중 이메일 중복확인 과정에서 탈퇴했던 유저인지 확인하는 로직을 추가하였습니다. 만일 탈퇴한 지 일주일이 지났으면 해당 유저의 데이터를 hard delete한 후 정상적으로 회원가입을 진행할 수 있도록 하였습니다. 이로인해 user Id 가 null 값이 될 수 있어 필요한 엔티티들의 설정을 변경하였습니다.

## 🧪 Test
사용자가 탈퇴하고 해당 이메일을 다시 사용하고자 하는 과정에서 검증 로직이 잘 동작하는지, 혹은 기존의 데이터가 잘 삭제되는지 확인해주시면 감사하겠습니다.

## 🎸 ETC
추가로 유저가 삭제되도 남아있는 엔티티들과 관련된 로직에서 삭제된 유저에 대한 처리가 되어있는지 확인이 필요할 것 같습니다. (좋아요나 반응 류는 상관없을 것 같은데 course Review파트가 좀 걱정되네요)
