### PR TITLE
Feature/announcement

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -66,7 +66,7 @@ export class AuthController {
   @ApiOperation({
     summary: '로그인',
     description: `로그인하여 JWT Token을 발급받습니다.
-      Access Token의 만료기간은 5분이고 Refresh Token의 만료기간은 로그인 유지가 참일 경우 30일, 아닐 경우 7일입니다.`,
+      Access Token의 만료기간은 5분이고 Refresh Token의 만료기간은 로그인 유지가 참일 경우 14일, 아닐 경우 2일입니다.`,
   })
   @ApiBody({
     type: LoginRequestDto,

--- a/src/entities/calendar.entity.ts
+++ b/src/entities/calendar.entity.ts
@@ -7,11 +7,17 @@ export class CalendarEntity extends CommonEntity {
   id: number;
 
   @Column('timestamp', { nullable: false })
-  date: Date;
+  startDate: Date;
+
+  @Column('timestamp', { nullable: false })
+  endDate: Date;
 
   @Column('varchar', { nullable: false })
   title: string;
 
   @Column('varchar', { nullable: false })
   description: string;
+
+  @Column('boolean', { nullable: false, default: false })
+  isAcademic: boolean;
 }

--- a/src/home/calendar/calendar.controller.ts
+++ b/src/home/calendar/calendar.controller.ts
@@ -42,7 +42,6 @@ import { GetAcademicScheduleDataResponseDto } from './dto/get-academic-schedule-
 
 @Controller('calendar')
 @ApiTags('calendar')
-@ApiBearerAuth('accessToken')
 export class CalendarController {
   constructor(private readonly calendarService: CalendarService) {}
 
@@ -93,6 +92,7 @@ export class CalendarController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.admin)
   @Get('yearly')
+  @ApiBearerAuth('accessToken')
   @ApiOperation({
     summary: '연도별 행사/일정 전체 조회',
     description:
@@ -113,6 +113,7 @@ export class CalendarController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.admin)
   @Post()
+  @ApiBearerAuth('accessToken')
   @ApiOperation({
     summary: '특정 날짜 행사/일정 생성',
     description: 'admin page에서 특정 날짜의 행사/일정을 생성합니다.',
@@ -131,6 +132,7 @@ export class CalendarController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.admin)
   @Patch('/:calendarId')
+  @ApiBearerAuth('accessToken')
   @ApiOperation({
     summary: '특정 행사/일정 수정',
     description:
@@ -152,6 +154,7 @@ export class CalendarController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.admin)
   @Delete('/:calendarId')
+  @ApiBearerAuth('accessToken')
   @ApiOperation({
     summary: '특정 행사/일정 삭제',
     description:

--- a/src/home/calendar/calendar.controller.ts
+++ b/src/home/calendar/calendar.controller.ts
@@ -11,6 +11,7 @@ import {
 } from '@nestjs/common';
 import { CalendarService } from './calendar.service';
 import {
+  ApiBearerAuth,
   ApiBody,
   ApiCreatedResponse,
   ApiOkResponse,
@@ -24,9 +25,9 @@ import {
   GetMonthlyCalendarDataResponseDto,
 } from './dto/get-calendar-data-response-dto';
 import {
-  GetMonthlyCalendarDataQueryDto,
-  GetYearlyCalendarDataQueryDto,
-} from './dto/get-calendar-data-query-dto';
+  GetMonthlyCalendarDataRequestDto,
+  GetYearlyCalendarDataRequestDto,
+} from './dto/get-calendar-data-request-dto';
 import { CreateCalendarDataRequestDto } from './dto/create-calendar-data-request.dto';
 import { CreateCalendarDataResponseDto } from './dto/create-calendar-data-response.dto';
 import { UpdateCalendarDataRequestDto } from './dto/update-calendar-data-request.dto';
@@ -36,9 +37,11 @@ import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/guards/role.guard';
 import { Roles } from 'src/decorators/roles.decorator';
 import { Role } from 'src/enums/role.enum';
+import { GetAcademicScheduleDataRequestDto } from './dto/get-academic-schedule-request.dto';
 
 @Controller('calendar')
 @ApiTags('calendar')
+@ApiBearerAuth('accessToken')
 export class CalendarController {
   constructor(private readonly calendarService: CalendarService) {}
 
@@ -56,7 +59,7 @@ export class CalendarController {
     type: GetDailyCalendarDataResponseDto,
   })
   async getMonthlyCalendarData(
-    @Query() queryDto: GetMonthlyCalendarDataQueryDto,
+    @Query() queryDto: GetMonthlyCalendarDataRequestDto,
   ): Promise<GetDailyCalendarDataResponseDto[]> {
     return await this.calendarService.getMonthlyCalendarData(
       queryDto.year,
@@ -64,6 +67,23 @@ export class CalendarController {
     );
   }
 
+  @Get('academic')
+  @ApiOperation({
+    summary: 'Academic Schedule 행사/일정 조회',
+    description:
+      '연도, 학기 정보를 받아 Academic Schedule에 해당하는 행사/일정을 조회합니다. 행사/일정이 존재하는 날짜의 경우에만 가져옵니다.',
+  })
+  @ApiQuery({ name: 'year', required: true, description: '연도' })
+  @ApiQuery({ name: 'semester', required: true, description: '학기' })
+  @ApiOkResponse({
+    description: '특정 연도, 학기별 Academic Schedule 행사/일정 데이터 반환',
+    isArray: true,
+    type: GetAcademicScheduleDataRequestDto,
+  })
+  async getAcademicScheduleData() {}
+
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.admin)
   @Get('yearly')
   @ApiOperation({
     summary: '연도별 행사/일정 전체 조회',
@@ -77,7 +97,7 @@ export class CalendarController {
     type: GetMonthlyCalendarDataResponseDto,
   })
   async getYearlyCalendarData(
-    @Query() queryDto: GetYearlyCalendarDataQueryDto,
+    @Query() queryDto: GetYearlyCalendarDataRequestDto,
   ): Promise<GetMonthlyCalendarDataResponseDto[]> {
     return await this.calendarService.getYearlyCalendarData(queryDto.year);
   }

--- a/src/home/calendar/calendar.controller.ts
+++ b/src/home/calendar/calendar.controller.ts
@@ -38,6 +38,7 @@ import { RolesGuard } from 'src/auth/guards/role.guard';
 import { Roles } from 'src/decorators/roles.decorator';
 import { Role } from 'src/enums/role.enum';
 import { GetAcademicScheduleDataRequestDto } from './dto/get-academic-schedule-request.dto';
+import { GetAcademicScheduleDataResponseDto } from './dto/get-academic-schedule-response.dto';
 
 @Controller('calendar')
 @ApiTags('calendar')
@@ -78,9 +79,16 @@ export class CalendarController {
   @ApiOkResponse({
     description: '특정 연도, 학기별 Academic Schedule 행사/일정 데이터 반환',
     isArray: true,
-    type: GetAcademicScheduleDataRequestDto,
+    type: GetAcademicScheduleDataResponseDto,
   })
-  async getAcademicScheduleData() {}
+  async getAcademicScheduleData(
+    @Query() queryDto: GetAcademicScheduleDataRequestDto,
+  ): Promise<GetAcademicScheduleDataResponseDto[]> {
+    return await this.calendarService.getAcademicScheduleData(
+      queryDto.year,
+      queryDto.semester,
+    );
+  }
 
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.admin)

--- a/src/home/calendar/calendar.repository.ts
+++ b/src/home/calendar/calendar.repository.ts
@@ -10,12 +10,14 @@ export class CalendarRepository extends Repository<CalendarEntity> {
   }
 
   async createCalendarData(
-    date: string,
+    startDate: string,
+    endDate: string,
     title: string,
     description: string,
   ): Promise<CalendarEntity> {
     const calendarData = this.create({
-      date: new Date(date),
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
       title,
       description,
     });
@@ -27,16 +29,17 @@ export class CalendarRepository extends Repository<CalendarEntity> {
     calendarId: number,
     requestDto: UpdateCalendarDataRequestDto,
   ): Promise<boolean> {
-    if (requestDto.date) {
-      const { date, ...others } = requestDto;
-      const newDate = new Date(date);
-      const updated = await this.update(
-        { id: calendarId },
-        { date: newDate, ...others },
-      );
-      return updated.affected ? true : false;
+    const updateData: any = { ...requestDto };
+
+    if (requestDto.startDate) {
+      updateData.startDate = new Date(requestDto.startDate);
     }
-    const updated = await this.update({ id: calendarId }, requestDto);
+
+    if (requestDto.endDate) {
+      updateData.endDate = new Date(requestDto.endDate);
+    }
+
+    const updated = await this.update({ id: calendarId }, updateData);
 
     return updated.affected ? true : false;
   }

--- a/src/home/calendar/calendar.repository.ts
+++ b/src/home/calendar/calendar.repository.ts
@@ -1,12 +1,35 @@
 import { Injectable } from '@nestjs/common';
 import { CalendarEntity } from 'src/entities/calendar.entity';
-import { DataSource, Repository } from 'typeorm';
+import {
+  DataSource,
+  LessThanOrEqual,
+  MoreThanOrEqual,
+  Repository,
+} from 'typeorm';
 import { UpdateCalendarDataRequestDto } from './dto/update-calendar-data-request.dto';
 
 @Injectable()
 export class CalendarRepository extends Repository<CalendarEntity> {
   constructor(dataSource: DataSource) {
     super(CalendarEntity, dataSource.createEntityManager());
+  }
+
+  // startDate ~ endDate 사이의 데이터 가져오기
+  async getMonthEvents(
+    startDate: Date,
+    endDate: Date,
+  ): Promise<CalendarEntity[]> {
+    return await this.find({
+      where: [
+        {
+          startDate: LessThanOrEqual(endDate),
+          endDate: MoreThanOrEqual(startDate),
+        },
+      ],
+      order: {
+        startDate: 'ASC',
+      },
+    });
   }
 
   async createCalendarData(

--- a/src/home/calendar/calendar.service.ts
+++ b/src/home/calendar/calendar.service.ts
@@ -113,12 +113,13 @@ export class CalendarService {
   async createCalendarData(
     requestDto: CreateCalendarDataRequestDto,
   ): Promise<CreateCalendarDataResponseDto> {
-    const { startDate, endDate, title, description } = requestDto;
+    const { startDate, endDate, title, description, isAcademic } = requestDto;
     const calendarData = await this.calendarRepository.createCalendarData(
       startDate,
       endDate,
       title,
       description,
+      isAcademic,
     );
 
     if (!calendarData) {
@@ -140,16 +141,10 @@ export class CalendarService {
       throw new NotFoundException('행사/일정 정보가 없습니다.');
     }
 
-    const isUpdated = await this.calendarRepository.updateCalendarData(
+    return await this.calendarRepository.updateCalendarData(
       calendarId,
       requestDto,
     );
-
-    if (!isUpdated) {
-      throw new InternalServerErrorException('업데이트에 실패했습니다.');
-    }
-
-    return new UpdateCalendarDataResponseDto(true);
   }
 
   async deleteCalendarData(

--- a/src/home/calendar/calendar.service.ts
+++ b/src/home/calendar/calendar.service.ts
@@ -11,7 +11,6 @@ import {
 } from './dto/get-calendar-data-response-dto';
 import { CreateCalendarDataRequestDto } from './dto/create-calendar-data-request.dto';
 import { CreateCalendarDataResponseDto } from './dto/create-calendar-data-response.dto';
-import { LessThanOrEqual, MoreThanOrEqual } from 'typeorm';
 import { UpdateCalendarDataRequestDto } from './dto/update-calendar-data-request.dto';
 import { UpdateCalendarDataResponseDto } from './dto/update-calendar-data-response.dto';
 import { DeleteCalendarDataResponseDto } from './dto/delete-calendar-data-response-dto';
@@ -31,14 +30,10 @@ export class CalendarService {
     const { startDate, endDate } = this.getStartAndEndDate(year, month);
 
     // 해당 월에 걸쳐있는 모든 이벤트를 가져옴
-    const monthEvents = await this.calendarRepository.find({
-      where: [
-        {
-          startDate: LessThanOrEqual(endDate),
-          endDate: MoreThanOrEqual(startDate),
-        },
-      ],
-    });
+    const monthEvents = await this.calendarRepository.getMonthEvents(
+      startDate,
+      endDate,
+    );
 
     const monthCalendarData: GetDailyCalendarDataResponseDto[] = [];
 
@@ -82,7 +77,7 @@ export class CalendarService {
     year: number,
     semester: number,
   ): Promise<GetAcademicScheduleDataResponseDto[]> {
-    const startMonth = semester === 1 ? 1 : 8;
+    const startMonth = semester === 1 ? 2 : 8;
     const endMonth = semester === 1 ? 8 : 14; // 13, 14는 다음해 1, 2월로 처리
     const academicScheduleData: GetAcademicScheduleDataResponseDto[] = [];
 

--- a/src/home/calendar/dto/create-calendar-data-request.dto.ts
+++ b/src/home/calendar/dto/create-calendar-data-request.dto.ts
@@ -7,8 +7,16 @@ export class CreateCalendarDataRequestDto {
   })
   @IsString()
   @IsNotEmpty()
-  @ApiProperty({ description: '날짜 (AAAA-BB-CC 형식)' })
-  date: string;
+  @ApiProperty({ description: '시작 날짜 (AAAA-BB-CC 형식)' })
+  startDate: string;
+
+  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
+    message: '날짜 형식이 잘못되었습니다.',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @ApiProperty({ description: '종료 날짜 (AAAA-BB-CC 형식)' })
+  endDate: string;
 
   @IsString()
   @IsNotEmpty()

--- a/src/home/calendar/dto/create-calendar-data-request.dto.ts
+++ b/src/home/calendar/dto/create-calendar-data-request.dto.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsNotEmpty, IsString, Matches } from 'class-validator';
+import { ToBoolean } from 'src/decorators/to-boolean.decorator';
 
 export class CreateCalendarDataRequestDto {
   @Matches(/^\d{4}-\d{2}-\d{2}$/, {
@@ -27,4 +28,9 @@ export class CreateCalendarDataRequestDto {
   @IsNotEmpty()
   @ApiProperty({ description: '행사/일정 설명' })
   description: string;
+
+  @IsNotEmpty()
+  @ToBoolean()
+  @ApiProperty({ description: '학사 일정 여부' })
+  isAcademic: boolean;
 }

--- a/src/home/calendar/dto/create-calendar-data-response.dto.ts
+++ b/src/home/calendar/dto/create-calendar-data-response.dto.ts
@@ -5,8 +5,11 @@ export class CreateCalendarDataResponseDto {
   @ApiProperty({ description: '행사/일정 id' })
   id: number;
 
-  @ApiProperty({ description: '날짜 (AAAA-BB-CC 형식)' })
-  date: Date;
+  @ApiProperty({ description: '시작 날짜 (AAAA-BB-CC 형식)' })
+  startDate: Date;
+
+  @ApiProperty({ description: '종료 날짜 (AAAA-BB-CC 형식)' })
+  endDate: Date;
 
   @ApiProperty({ description: '행사/일정 제목' })
   title: string;
@@ -16,7 +19,8 @@ export class CreateCalendarDataResponseDto {
 
   constructor(calendar: CalendarEntity) {
     this.id = calendar.id;
-    this.date = calendar.date;
+    this.startDate = calendar.startDate;
+    this.endDate = calendar.endDate;
     this.title = calendar.title;
     this.description = calendar.description;
   }

--- a/src/home/calendar/dto/create-calendar-data-response.dto.ts
+++ b/src/home/calendar/dto/create-calendar-data-response.dto.ts
@@ -17,11 +17,15 @@ export class CreateCalendarDataResponseDto {
   @ApiProperty({ description: '행사/일정 설명' })
   description: string;
 
+  @ApiProperty({ description: '학사 일정 여부' })
+  isAcademic: boolean;
+
   constructor(calendar: CalendarEntity) {
     this.id = calendar.id;
     this.startDate = calendar.startDate;
     this.endDate = calendar.endDate;
     this.title = calendar.title;
     this.description = calendar.description;
+    this.isAcademic = calendar.isAcademic;
   }
 }

--- a/src/home/calendar/dto/get-academic-schedule-request.dto.ts
+++ b/src/home/calendar/dto/get-academic-schedule-request.dto.ts
@@ -1,0 +1,18 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsInt, IsNotEmpty, Max, Min } from 'class-validator';
+
+export class GetAcademicScheduleDataRequestDto {
+  @IsInt()
+  @IsNotEmpty()
+  @Max(2030)
+  @Min(2024)
+  @ApiProperty({ description: '조회할 연도' })
+  year: number;
+
+  @IsInt()
+  @IsNotEmpty()
+  @Max(2)
+  @Min(1)
+  @ApiProperty({ description: '조회할 학기' })
+  semester: number;
+}

--- a/src/home/calendar/dto/get-academic-schedule-response.dto.ts
+++ b/src/home/calendar/dto/get-academic-schedule-response.dto.ts
@@ -1,6 +1,16 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { CalendarEntity } from 'src/entities/calendar.entity';
 
+enum DayOfWeek {
+  SUN = 0,
+  MON = 1,
+  TUE = 2,
+  WED = 3,
+  THU = 4,
+  FRI = 5,
+  SAT = 6,
+}
+
 class AcademicSchedule {
   @ApiProperty({ description: '행사/일정 제목' })
   title: string;
@@ -12,21 +22,21 @@ class AcademicSchedule {
   startDate: Date;
 
   @ApiProperty({ description: '시작 요일' })
-  startDay: number;
+  startDay: string;
 
   @ApiProperty({ description: '종료 날짜' })
   endDate: Date;
 
   @ApiProperty({ description: '종료 요일' })
-  endDay: number;
+  endDay: string;
 
   constructor(calendar: CalendarEntity) {
     this.title = calendar.title;
     this.description = calendar.description;
     this.startDate = calendar.startDate;
-    this.startDay = this.startDate.getDay();
+    this.startDay = DayOfWeek[this.startDate.getDay()];
     this.endDate = calendar.endDate;
-    this.endDay = this.endDate.getDay();
+    this.endDay = DayOfWeek[this.endDate.getDay()];
   }
 }
 
@@ -40,8 +50,10 @@ export class GetAcademicScheduleDataResponseDto {
   })
   schedules: AcademicSchedule[];
 
-  constructor(month: number, schedules: AcademicSchedule[]) {
+  constructor(month: number, calendars: CalendarEntity[]) {
     this.month = month;
-    this.schedules = schedules;
+    this.schedules = calendars.map((calendar) => {
+      return new AcademicSchedule(calendar);
+    });
   }
 }

--- a/src/home/calendar/dto/get-academic-schedule-response.dto.ts
+++ b/src/home/calendar/dto/get-academic-schedule-response.dto.ts
@@ -1,0 +1,47 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CalendarEntity } from 'src/entities/calendar.entity';
+
+class AcademicSchedule {
+  @ApiProperty({ description: '행사/일정 제목' })
+  title: string;
+
+  @ApiProperty({ description: '행사/일정 설명' })
+  description: string;
+
+  @ApiProperty({ description: '시작 날짜' })
+  startDate: Date;
+
+  @ApiProperty({ description: '시작 요일' })
+  startDay: number;
+
+  @ApiProperty({ description: '종료 날짜' })
+  endDate: Date;
+
+  @ApiProperty({ description: '종료 요일' })
+  endDay: number;
+
+  constructor(calendar: CalendarEntity) {
+    this.title = calendar.title;
+    this.description = calendar.description;
+    this.startDate = calendar.startDate;
+    this.startDay = this.startDate.getDay();
+    this.endDate = calendar.endDate;
+    this.endDay = this.endDate.getDay();
+  }
+}
+
+export class GetAcademicScheduleDataResponseDto {
+  @ApiProperty({ description: '월' })
+  month: number;
+
+  @ApiProperty({
+    description: '월별 Academic Schedule 행사/일정',
+    type: [AcademicSchedule],
+  })
+  schedules: AcademicSchedule[];
+
+  constructor(month: number, schedules: AcademicSchedule[]) {
+    this.month = month;
+    this.schedules = schedules;
+  }
+}

--- a/src/home/calendar/dto/get-calendar-data-request-dto.ts
+++ b/src/home/calendar/dto/get-calendar-data-request-dto.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsInt, IsNotEmpty, Max, Min } from 'class-validator';
 
-export class GetMonthlyCalendarDataQueryDto {
+export class GetMonthlyCalendarDataRequestDto {
   @IsInt()
   @IsNotEmpty()
   @Max(2030)
@@ -17,7 +17,7 @@ export class GetMonthlyCalendarDataQueryDto {
   month: number;
 }
 
-export class GetYearlyCalendarDataQueryDto {
+export class GetYearlyCalendarDataRequestDto {
   @IsInt()
   @IsNotEmpty()
   @Max(2030)

--- a/src/home/calendar/dto/update-calendar-data-request.dto.ts
+++ b/src/home/calendar/dto/update-calendar-data-request.dto.ts
@@ -1,22 +1,6 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsString, Matches } from 'class-validator';
+import { PartialType } from '@nestjs/swagger';
+import { CreateCalendarDataRequestDto } from './create-calendar-data-request.dto';
 
-export class UpdateCalendarDataRequestDto {
-  @Matches(/^\d{4}-\d{2}-\d{2}$/, {
-    message: '날짜 형식이 잘못되었습니다.',
-  })
-  @IsString()
-  @IsOptional()
-  @ApiProperty({ description: '날짜 (AAAA-BB-CC 형식)' })
-  date: string;
-
-  @IsString()
-  @IsOptional()
-  @ApiProperty({ description: '행사/일정 제목' })
-  title: string;
-
-  @IsString()
-  @IsOptional()
-  @ApiProperty({ description: '행사/일정 설명' })
-  description: string;
-}
+export class UpdateCalendarDataRequestDto extends PartialType(
+  CreateCalendarDataRequestDto,
+) {}

--- a/src/home/calendar/dto/update-calendar-data-response.dto.ts
+++ b/src/home/calendar/dto/update-calendar-data-response.dto.ts
@@ -1,10 +1,31 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { CalendarEntity } from 'src/entities/calendar.entity';
 
 export class UpdateCalendarDataResponseDto {
-  @ApiProperty({ description: '업데이트 여부' })
-  updated: boolean;
+  @ApiProperty({ description: '행사/일정 id' })
+  id: number;
 
-  constructor(updated: boolean) {
-    this.updated = updated;
+  @ApiProperty({ description: '시작 날짜 (AAAA-BB-CC 형식)' })
+  startDate: Date;
+
+  @ApiProperty({ description: '종료 날짜 (AAAA-BB-CC 형식)' })
+  endDate: Date;
+
+  @ApiProperty({ description: '행사/일정 제목' })
+  title: string;
+
+  @ApiProperty({ description: '행사/일정 설명' })
+  description: string;
+
+  @ApiProperty({ description: '학사 일정 여부' })
+  isAcademic: boolean;
+
+  constructor(calendar: CalendarEntity) {
+    this.id = calendar.id;
+    this.startDate = calendar.startDate;
+    this.endDate = calendar.endDate;
+    this.title = calendar.title;
+    this.description = calendar.description;
+    this.isAcademic = calendar.isAcademic;
   }
 }

--- a/src/home/institution/institution.controller.ts
+++ b/src/home/institution/institution.controller.ts
@@ -12,6 +12,7 @@ import {
 } from '@nestjs/common';
 import { InstitutionService } from './institution.service';
 import {
+  ApiBearerAuth,
   ApiBody,
   ApiCreatedResponse,
   ApiOkResponse,
@@ -53,6 +54,7 @@ export class InstitutionController {
   @Roles(Role.admin)
   @UseInterceptors(FileInterceptor('logoImage'))
   @Post()
+  @ApiBearerAuth('accessToken')
   @ApiOperation({
     summary: '기관 추가',
     description: 'admin page에서 기관 정보를 추가합니다.',
@@ -73,6 +75,7 @@ export class InstitutionController {
   @Roles(Role.admin)
   @UseInterceptors(FileInterceptor('logoImage'))
   @Patch('/:institutionId')
+  @ApiBearerAuth('accessToken')
   @ApiOperation({
     summary: '기관 정보 수정',
     description: '기관 id를 받아 admin page에서 기관 정보를 수정합니다.',
@@ -98,6 +101,7 @@ export class InstitutionController {
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(Role.admin)
   @Delete('/:institutionId')
+  @ApiBearerAuth('accessToken')
   @ApiOperation({
     summary: '기관 정보 삭제',
     description: '기관 id를 받아 admin page에서 기관 정보를 삭제합니다.',


### PR DESCRIPTION
## 📝 Description
- calendar entity가 일부 수정되었습니다. 원래 date 하루만 저장했었는데, startDate / endDate를 저장하여 여러 날에 걸친 행사/일정을 하나의 row로 관리하도록 했습니다.
- entity 수정에 따라 기존 로직들이 일부 변경되었습니다. 어드민 페이지에도 빠른 시일 내에 적용시키겠읍니다...
- academic schedule 페이지를 위한 api 하나 추가했습니다.

## 🧪 Test
기존 / 새로 추가한 api 잘 동작하는지
추가로 연도별 행사/일정 반환은 이제 어드민 페이지용으로만 쓰여서 가드 달아뒀읍니당

## 🎸 ETC
얘네랑 관련없지만 로그인 로직 스웨거가 업데이트 안된 부분이 있어서 (리프레쉬 유지 기간) 수정해두었습니다~