### PR TITLE
feature/courseReview

### DIFF
--- a/src/course-review/course-review.service.ts
+++ b/src/course-review/course-review.service.ts
@@ -205,6 +205,7 @@ export class CourseReviewService {
       },
       order: { [criteria]: direction },
       relations: ['user'],
+      withDeleted: true,
     });
 
     if (courseReviews.length === 0) {

--- a/src/course-review/dto/get-course-reviews-response.dto.ts
+++ b/src/course-review/dto/get-course-reviews-response.dto.ts
@@ -48,9 +48,11 @@ export class ReviewDto {
     this.id = courseReviewEntity.id;
     this.rate = courseReviewEntity.rate;
     this.createdAt = courseReviewEntity.createdAt;
-    this.reviewer = courseReviewEntity.user.deletedAt
-      ? 'Deleted'
-      : courseReviewEntity.user.username;
+    this.reviewer = courseReviewEntity.user
+      ? courseReviewEntity.user.deletedAt
+        ? 'Deleted'
+        : courseReviewEntity.user.username
+      : 'Deleted';
     this.year = courseReviewEntity.year;
     this.semester = courseReviewEntity.semester;
     this.myRecommend = myRecommend;

--- a/src/course-review/dto/get-course-reviews-response.dto.ts
+++ b/src/course-review/dto/get-course-reviews-response.dto.ts
@@ -48,7 +48,9 @@ export class ReviewDto {
     this.id = courseReviewEntity.id;
     this.rate = courseReviewEntity.rate;
     this.createdAt = courseReviewEntity.createdAt;
-    this.reviewer = courseReviewEntity.user.username;
+    this.reviewer = courseReviewEntity.user.deletedAt
+      ? 'Deleted'
+      : courseReviewEntity.user.username;
     this.year = courseReviewEntity.year;
     this.semester = courseReviewEntity.semester;
     this.myRecommend = myRecommend;


### PR DESCRIPTION
## 📝 Description
탈퇴한 유저가 작성한 강의평이 조회될 시 에러 나오는 부분 수정하고, 그 유저의 이름 (reviewer) 부분은 deleted가 되도록 했습니다.

## 🧪 Test
회원탈퇴를 통해 soft delete 되었을 때도 강의평 조회 시 'Deleted'가 나오는지, hard delete를 해서 해당 유저의 row가 삭제되었을 때도 강의평 조회 시 'Deleted'가 나오는지
