### PR TITLE
Feature/community

### DIFF
--- a/src/community/post/dto/community-user.dto.ts
+++ b/src/community/post/dto/community-user.dto.ts
@@ -4,9 +4,9 @@ import { UserEntity } from 'src/entities/user.entity';
 import { CharacterType } from 'src/enums/character-type.enum';
 
 export class Character {
-  constructor(characterEntity?: CharacterEntity) {
-    this.type = characterEntity?.type ?? CharacterType.default;
-    this.level = characterEntity?.level ?? null;
+  constructor(characterEntity: CharacterEntity) {
+    this.type = characterEntity.type;
+    this.level = characterEntity.level;
   }
 
   @ApiProperty({ description: '캐릭터 종류', enum: CharacterType })
@@ -25,7 +25,7 @@ export class CommunityUser {
     if (user == null || user.deletedAt) {
       this.username = 'Deleted';
       this.isDeleted = true;
-      this.character = new Character();
+      this.character = { type: CharacterType.deleted, level: null };
     } else {
       if (!isAnonymous) {
         this.username =
@@ -39,7 +39,7 @@ export class CommunityUser {
         else if (!anonymousNumber) this.username = 'Anonymous';
         else this.username = `Anonymous ${anonymousNumber}`;
         this.isAnonymous = true;
-        this.character = new Character();
+        this.character = { type: CharacterType.anonymous, level: null };
       }
     }
   }

--- a/src/community/post/post.controller.ts
+++ b/src/community/post/post.controller.ts
@@ -188,6 +188,7 @@ export class PostController {
   }
 
   @Post()
+  @UseInterceptors(TransactionInterceptor)
   @UseInterceptors(FilesInterceptor('images'))
   @ApiOperation({
     summary: '게시글 생성',
@@ -207,6 +208,7 @@ export class PostController {
     type: GetPostResponseDto,
   })
   async createPost(
+    @TransactionManager() transactionManager: EntityManager,
     @User() user: AuthorizedUserDto,
     @Query('boardId') boardId: number,
     @UploadedFiles() images: Array<Express.Multer.File>,
@@ -215,10 +217,17 @@ export class PostController {
     if (!boardId) {
       throw new BadRequestException('No BoardId!');
     }
-    return await this.postService.createPost(user, boardId, images, body);
+    return await this.postService.createPost(
+      transactionManager,
+      user,
+      boardId,
+      images,
+      body,
+    );
   }
 
   @Patch('/:postId')
+  @UseInterceptors(TransactionInterceptor)
   @UseInterceptors(FilesInterceptor('images'))
   @ApiOperation({
     summary: '게시글 수정',
@@ -238,12 +247,19 @@ export class PostController {
     type: GetPostResponseDto,
   })
   async updatePost(
+    @TransactionManager() transactionManager: EntityManager,
     @User() user: AuthorizedUserDto,
     @Param('postId') postId: number,
     @UploadedFiles() images: Array<Express.Multer.File>,
     @Body() body: UpdatePostRequestDto,
   ): Promise<GetPostResponseDto> {
-    return await this.postService.updatePost(user, postId, images, body);
+    return await this.postService.updatePost(
+      transactionManager,
+      user,
+      postId,
+      images,
+      body,
+    );
   }
 
   @Delete('/:postId')
@@ -268,6 +284,7 @@ export class PostController {
   }
 
   @Post('/:postId/scrap')
+  @UseInterceptors(TransactionInterceptor)
   @ApiOperation({
     summary: '게시글 스크랩',
     description:
@@ -283,10 +300,11 @@ export class PostController {
     type: ScrapPostResponseDto,
   })
   async scrapPost(
+    @TransactionManager() transactionManager: EntityManager,
     @User() user: AuthorizedUserDto,
     @Param('postId') postId: number,
   ): Promise<ScrapPostResponseDto> {
-    return await this.postService.scrapPost(user, postId);
+    return await this.postService.scrapPost(transactionManager, user, postId);
   }
 
   @Post('/:postId/reaction')

--- a/src/community/post/post.service.ts
+++ b/src/community/post/post.service.ts
@@ -16,7 +16,7 @@ import { FileService } from 'src/common/file.service';
 import { GetPostResponseDto } from './dto/get-post.dto';
 import { UpdatePostRequestDto } from './dto/update-post.dto';
 import { DeletePostResponseDto } from './dto/delete-post.dto';
-import { DataSource, EntityManager, Repository } from 'typeorm';
+import { EntityManager, Repository } from 'typeorm';
 import { PostEntity } from 'src/entities/post.entity';
 import { PostImageEntity } from 'src/entities/post-image.entity';
 import { PostScrapRepository } from './post-scrap.repository';
@@ -52,7 +52,6 @@ export class PostService {
     private readonly fileService: FileService,
     private readonly pointService: PointService,
     private readonly noticeService: NoticeService,
-    private readonly dataSource: DataSource,
     @Inject(CACHE_MANAGER) private readonly cacheManager: Cache,
   ) {}
 
@@ -126,6 +125,7 @@ export class PostService {
   }
 
   async createPost(
+    transactionManager: EntityManager,
     user: AuthorizedUserDto,
     boardId: number,
     images: Array<Express.Multer.File>,
@@ -146,44 +146,41 @@ export class PostService {
       throw new BadRequestException('Wrong BoardId!');
     }
 
-    let newPostId: number;
+    const post = transactionManager.create(PostEntity, {
+      userId: user.id,
+      boardId: boardId,
+      title: requestDto.title,
+      content: requestDto.content,
+      isAnonymous: requestDto.isAnonymous,
+    });
+    const newPostId = (await transactionManager.save(post)).id;
 
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
-    try {
-      const post = queryRunner.manager.create(PostEntity, {
-        userId: user.id,
-        boardId: boardId,
-        title: requestDto.title,
-        content: requestDto.content,
-        isAnonymous: requestDto.isAnonymous,
+    for (const image of images) {
+      const imgDir = await this.fileService.uploadFile(
+        image,
+        'PostImage',
+        `${newPostId}`,
+      );
+      const postImage = transactionManager.create(PostImageEntity, {
+        postId: newPostId,
+        imgDir: imgDir,
       });
-      newPostId = (await queryRunner.manager.save(post)).id;
-
-      for (const image of images) {
-        const imgDir = await this.fileService.uploadFile(
-          image,
-          'PostImage',
-          `${newPostId}`,
-        );
-        const postImage = queryRunner.manager.create(PostImageEntity, {
-          postId: newPostId,
-          imgDir: imgDir,
-        });
-        await queryRunner.manager.save(postImage);
-      }
-
-      await queryRunner.commitTransaction();
-    } catch (err) {
-      await queryRunner.rollbackTransaction();
-      throw err;
-    } finally {
-      await queryRunner.release();
+      await transactionManager.save(postImage);
     }
 
-    const createdPost =
-      await this.postRepository.getPostByPostIdWithDeletedComment(newPostId);
+    const createdPost = await transactionManager.findOne(PostEntity, {
+      where: { id: newPostId },
+      withDeleted: true,
+      relations: [
+        'user.character',
+        'postImages',
+        'comments.user.character',
+        'comments.commentLikes',
+        'commentAnonymousNumbers',
+        'postScraps',
+        'postReactions',
+      ],
+    });
 
     const postResponse = new GetPostResponseDto(createdPost, user.id);
     this.makeImgDirUrlInPost(postResponse);
@@ -192,6 +189,7 @@ export class PostService {
   }
 
   async updatePost(
+    transactionManager: EntityManager,
     user: AuthorizedUserDto,
     postId: number,
     images: Array<Express.Multer.File>,
@@ -223,52 +221,51 @@ export class PostService {
       }
     }
 
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
-    try {
-      await queryRunner.manager.update(
-        PostEntity,
-        { id: postId },
-        {
-          title: requestDto.title,
-          content: requestDto.content,
-          isAnonymous: requestDto.isAnonymous,
-        },
-      );
+    await transactionManager.update(
+      PostEntity,
+      { id: postId },
+      {
+        title: requestDto.title,
+        content: requestDto.content,
+        isAnonymous: requestDto.isAnonymous,
+      },
+    );
 
-      if (requestDto.imageUpdate) {
-        for (const image of post.postImages) {
-          await this.fileService.deleteFile(image.imgDir);
-          await queryRunner.manager.softDelete(PostImageEntity, {
-            id: image.id,
-          });
-        }
-
-        for (const image of images) {
-          const imgDir = await this.fileService.uploadFile(
-            image,
-            'PostImage',
-            `${postId}`,
-          );
-          const postImage = queryRunner.manager.create(PostImageEntity, {
-            postId: postId,
-            imgDir: imgDir,
-          });
-          await queryRunner.manager.save(postImage);
-        }
+    if (requestDto.imageUpdate) {
+      for (const image of post.postImages) {
+        await this.fileService.deleteFile(image.imgDir);
+        await transactionManager.softDelete(PostImageEntity, {
+          id: image.id,
+        });
       }
 
-      await queryRunner.commitTransaction();
-    } catch (err) {
-      await queryRunner.rollbackTransaction();
-      throw err;
-    } finally {
-      await queryRunner.release();
+      for (const image of images) {
+        const imgDir = await this.fileService.uploadFile(
+          image,
+          'PostImage',
+          `${postId}`,
+        );
+        const postImage = transactionManager.create(PostImageEntity, {
+          postId: postId,
+          imgDir: imgDir,
+        });
+        await transactionManager.save(postImage);
+      }
     }
 
-    const updatedPost =
-      await this.postRepository.getPostByPostIdWithDeletedComment(postId);
+    const updatedPost = await transactionManager.findOne(PostEntity, {
+      where: { id: postId },
+      withDeleted: true,
+      relations: [
+        'user.character',
+        'postImages',
+        'comments.user.character',
+        'comments.commentLikes',
+        'commentAnonymousNumbers',
+        'postScraps',
+        'postReactions',
+      ],
+    });
     const postResponse = new GetPostResponseDto(updatedPost, user.id);
     this.makeImgDirUrlInPost(postResponse);
 
@@ -304,6 +301,7 @@ export class PostService {
   }
 
   async scrapPost(
+    transactionManager: EntityManager,
     user: AuthorizedUserDto,
     postId: number,
   ): Promise<ScrapPostResponseDto> {
@@ -317,62 +315,50 @@ export class PostService {
       throw new BadRequestException('Cannot scrap my post!');
     }
 
-    const queryRunner = this.dataSource.createQueryRunner();
-    await queryRunner.connect();
-    await queryRunner.startTransaction();
+    const scrap = await transactionManager.findOne(PostScrapEntity, {
+      where: {
+        userId: user.id,
+        postId: postId,
+      },
+    });
 
-    try {
-      const scrap = await queryRunner.manager.findOne(PostScrapEntity, {
-        where: {
-          userId: user.id,
-          postId: postId,
-        },
+    if (scrap) {
+      const deleteResult = await transactionManager.delete(PostScrapEntity, {
+        userId: user.id,
+        postId: postId,
       });
-
-      if (scrap) {
-        const deleteResult = await queryRunner.manager.delete(PostScrapEntity, {
-          userId: user.id,
-          postId: postId,
-        });
-        if (!deleteResult.affected) {
-          throw new InternalServerErrorException('Scrap Cancel Failed!');
-        }
-
-        const updateResult = await queryRunner.manager.decrement(
-          PostEntity,
-          { id: postId },
-          'scrapCount',
-          1,
-        );
-        if (!updateResult.affected) {
-          throw new InternalServerErrorException('Scrap Cancel Failed!');
-        }
-      } else {
-        const newScrap = queryRunner.manager.create(PostScrapEntity, {
-          userId: user.id,
-          postId: postId,
-        });
-        await queryRunner.manager.save(newScrap);
-
-        const updateResult = await queryRunner.manager.increment(
-          PostEntity,
-          { id: postId },
-          'scrapCount',
-          1,
-        );
-        if (!updateResult.affected) {
-          throw new InternalServerErrorException('Scrap Failed!');
-        }
+      if (!deleteResult.affected) {
+        throw new InternalServerErrorException('Scrap Cancel Failed!');
       }
-      await queryRunner.commitTransaction();
 
-      return new ScrapPostResponseDto(scrap ? false : true);
-    } catch (err) {
-      await queryRunner.rollbackTransaction();
-      throw err;
-    } finally {
-      await queryRunner.release();
+      const updateResult = await transactionManager.decrement(
+        PostEntity,
+        { id: postId },
+        'scrapCount',
+        1,
+      );
+      if (!updateResult.affected) {
+        throw new InternalServerErrorException('Scrap Cancel Failed!');
+      }
+    } else {
+      const newScrap = transactionManager.create(PostScrapEntity, {
+        userId: user.id,
+        postId: postId,
+      });
+      await transactionManager.save(newScrap);
+
+      const updateResult = await transactionManager.increment(
+        PostEntity,
+        { id: postId },
+        'scrapCount',
+        1,
+      );
+      if (!updateResult.affected) {
+        throw new InternalServerErrorException('Scrap Failed!');
+      }
     }
+
+    return new ScrapPostResponseDto(scrap ? false : true);
   }
 
   async getMyPostList(

--- a/src/enums/character-type.enum.ts
+++ b/src/enums/character-type.enum.ts
@@ -4,5 +4,6 @@ export enum CharacterType {
   character3 = 'character3',
   character4 = 'character4',
   character5 = 'character5',
-  default = 'default',
+  anonymous = 'anonymous',
+  deleted = 'deleted',
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -299,18 +299,16 @@ export class UserService {
   }
 
   private getRandomCharacterType(existingType?: CharacterType): CharacterType {
-    const characterTypes = Object.values(CharacterType);
-    if (existingType) {
-      // 기존 타입을 제외한 나머지에서 랜덤 선택
-      const availableTypes = characterTypes.filter(
-        (type) => type !== existingType,
-      );
-      const randomIndex = Math.floor(Math.random() * availableTypes.length);
-      return availableTypes[randomIndex];
-    } else {
-      const randomIndex = Math.floor(Math.random() * characterTypes.length);
-      return characterTypes[randomIndex];
-    }
+    const excludedTypes = [CharacterType.anonymous, CharacterType.deleted];
+    if (existingType) excludedTypes.push(existingType);
+
+    // 기존 타입을 제외한 나머지에서 랜덤 선택
+    const availableTypes = Object.values(CharacterType).filter(
+      (type) => !excludedTypes.includes(type),
+    );
+
+    const randomIndex = Math.floor(Math.random() * availableTypes.length);
+    return availableTypes[randomIndex];
   }
 
   private generateDefaultExpiredate(): Date {


### PR DESCRIPTION
## 📝 Description
댓글작성시 알림발송 로직까지 하나의 트랜잭션에 포함
캐릭터 default 타입을 익명/삭제 두가지로 분리

## ✨ To Discuss
알림발송시 보낸 알림을 db에 insert하는 과정에서 진행이 안되고 데드락이 발생하는 것을 확인해서 우선 하나의 트랜잭션에 포함시키도록 수정하였는데 알림쪽에서 에러가 나면 댓글생성이 안되는 상황이 발생할지도..? 이게 맞는걸까요

## 🧪 Test
댓글 작성이나 게시글 관련된 부분은 기존과 동일하게 작동하는지
캐릭터가 삭제/익명에 맞게 나타나는지
캐릭터변경권을 구매하였을때 올바르게 나타나는지

## 🎸 ETC
겸사겸사 커뮤니티쪽에 transaction 인터셉터 적용하였습니다.

