### PR TITLE
feature/user

### DIFF
--- a/src/user/dto/get-profile-response.dto.ts
+++ b/src/user/dto/get-profile-response.dto.ts
@@ -5,8 +5,8 @@ import { CharacterType } from 'src/enums/character-type.enum';
 import { Language } from 'src/enums/language';
 
 export class GetProfileResponseDto {
-  @ApiProperty({ description: '본명' })
-  name: string;
+  @ApiProperty({ description: '유저아이디' })
+  username: string;
 
   @ApiProperty({ description: '국적' })
   country: string;
@@ -43,7 +43,7 @@ export class GetProfileResponseDto {
   selectedLevel: number;
 
   constructor(user: UserEntity, character: CharacterEntity) {
-    this.name = user.name;
+    this.username = user.username;
     this.country = user.country;
     this.homeUniversity = user.homeUniversity;
     this.major = user.major;

--- a/src/user/dto/set-profile-request.dto.ts
+++ b/src/user/dto/set-profile-request.dto.ts
@@ -4,8 +4,8 @@ import { IsDate, IsNotEmpty, IsOptional, IsString } from 'class-validator';
 export class SetProfileRequestDto {
   @IsOptional()
   @IsString()
-  @ApiProperty({ description: '본명' })
-  name: string;
+  @ApiProperty({ description: '유저아이디' })
+  username: string;
 
   @IsOptional()
   @IsString()


### PR DESCRIPTION
## 📝 Description
프로필 조회 시 본명 대신 username(친추추가 ID) 뜨도록 변경
프로필 수정 시 본명 대신 username(친추추가 ID) 수정하도록 변경

## 🧪 Test
수정사항 잘 동작하는지

## 🎸 ETC
username 중복확인 엔드포인트가 이미 존재하여 따로 로직을 추가로 구성하지는 않았습니다.
