### PR TITLE
Feature/community

### DIFF
--- a/src/community/comment/comment.repository.ts
+++ b/src/community/comment/comment.repository.ts
@@ -11,7 +11,7 @@ export class CommentRepository extends Repository<CommentEntity> {
   async getCommentByCommentId(commentId: number) {
     const comment = await this.findOne({
       where: { id: commentId },
-      relations: ['parentComment', 'user.character', 'commentLikes'],
+      relations: ['parentComment', 'user.character', 'commentLikes', 'post'],
     });
 
     return comment;

--- a/src/community/comment/comment.service.ts
+++ b/src/community/comment/comment.service.ts
@@ -113,7 +113,7 @@ export class CommentService {
     if (myAnonymousNumber) {
       anonymousNumber = myAnonymousNumber.anonymousNumber;
     } else {
-      if (post.userId === user.id) {
+      if (post.isAnonymous && post.userId === user.id) {
         anonymousNumber = 0;
       } else {
         const recentAnonymousNumber = await transactionManager.findOne(

--- a/src/community/comment/comment.service.ts
+++ b/src/community/comment/comment.service.ts
@@ -142,7 +142,7 @@ export class CommentService {
 
     const createdComment = await transactionManager.findOne(CommentEntity, {
       where: { id: newCommentId },
-      relations: ['parentComment', 'user.character', 'commentLikes'],
+      relations: ['parentComment', 'user.character', 'commentLikes', 'post'],
     });
     if (post.userId !== user.id) {
       await this.noticeService.emitNotice(

--- a/src/community/comment/dto/get-comment.dto.ts
+++ b/src/community/comment/dto/get-comment.dto.ts
@@ -14,6 +14,7 @@ export class GetCommentResponseDto {
     this.updatedAt = commentEntity.updatedAt;
     if (this.isDeleted) {
       this.isMyComment = false;
+      this.isAuthor = false;
       this.content = null;
       this.user = {
         username: null,
@@ -25,6 +26,9 @@ export class GetCommentResponseDto {
       this.myLike = false;
     } else {
       this.isMyComment = commentEntity.userId === userId;
+      this.isAuthor =
+        commentEntity.post.isAnonymous === commentEntity.isAnonymous &&
+        commentEntity.post.userId === commentEntity.userId;
       this.content = commentEntity.content;
       this.user = new CommunityUser(
         commentEntity.user,
@@ -51,6 +55,9 @@ export class GetCommentResponseDto {
 
   @ApiProperty({ description: '본인이 작성한 댓글인지 여부' })
   isMyComment?: boolean;
+
+  @ApiProperty({ description: '게시글 작성자의 댓글인지 여부' })
+  isAuthor?: boolean;
 
   @ApiProperty({ description: '댓글 내용' })
   content?: string;

--- a/src/community/comment/dto/get-comment.dto.ts
+++ b/src/community/comment/dto/get-comment.dto.ts
@@ -6,7 +6,7 @@ export class GetCommentResponseDto {
   constructor(
     commentEntity: CommentEntity,
     userId: number,
-    anonymousNumber: number,
+    anonymousNumber?: number,
   ) {
     this.id = commentEntity.id;
     this.isDeleted = commentEntity.deletedAt ? true : false;

--- a/src/community/post/dto/get-post.dto.ts
+++ b/src/community/post/dto/get-post.dto.ts
@@ -86,6 +86,7 @@ export class GetPostResponseDto {
           (commentAnonymousNumber) =>
             commentAnonymousNumber.userId === comment.userId,
         )[0]?.anonymousNumber;
+        comment.post = postEntity;
         if (!comment.parentCommentId) {
           this.comments.push(new Comment(comment, userId, anonymousNumber));
         } else {

--- a/src/community/post/dto/get-post.dto.ts
+++ b/src/community/post/dto/get-post.dto.ts
@@ -10,7 +10,7 @@ class Comment extends GetCommentResponseDto {
   constructor(
     commentEntity: CommentEntity,
     userId: number,
-    anonymousNumber: number,
+    anonymousNumber?: number,
   ) {
     super(commentEntity, userId, anonymousNumber);
     if (!commentEntity.parentCommentId) {
@@ -85,7 +85,7 @@ export class GetPostResponseDto {
         const anonymousNumber = postEntity.commentAnonymousNumbers.filter(
           (commentAnonymousNumber) =>
             commentAnonymousNumber.userId === comment.userId,
-        )[0].anonymousNumber;
+        )[0]?.anonymousNumber;
         if (!comment.parentCommentId) {
           this.comments.push(new Comment(comment, userId, anonymousNumber));
         } else {


### PR DESCRIPTION
## 📝 Description
유저가 탈퇴(hard delete) 되었을 때 익명번호가 제대로 접근되지 않아 발생하던 오류 수정
댓글이 게시글 작성자의 것인지 나타내는 기능 추가



## 🧪 Test
유저가 탈퇴되었을 때(hard delete되고 그로인해 익명번호 데이터가 사라졌을 때) 그 유저의 댓글이 달린 게시글 조회가 잘 되는지
익명게시글 - 작성자가 익명/ 실명으로 댓글을 남겼을 때
실명게시글 - 작성자가 익명/ 실명으로 댓글을 남겼을 때
4가지 경우 모두 잘 동작하는지

