### PR TITLE
Feature/swagger

### DIFF
--- a/src/common/dto/CursorPageResponse.dto.ts
+++ b/src/common/dto/CursorPageResponse.dto.ts
@@ -1,17 +1,5 @@
-import { ApiExtraModels, ApiProperty, getSchemaPath } from '@nestjs/swagger';
-import { MyComment } from 'src/community/comment/dto/get-comment.dto';
-import {
-  PostPreview,
-  PostPreviewWithBoardName,
-} from 'src/community/post/dto/post-preview.dto';
-import { GetNoticeResponseDto } from 'src/notice/dto/get-notice.dto';
+import { ApiProperty } from '@nestjs/swagger';
 
-@ApiExtraModels(
-  GetNoticeResponseDto,
-  PostPreview,
-  PostPreviewWithBoardName,
-  MyComment,
-)
 export class CursorPageMetaResponseDto {
   @ApiProperty({ description: '다음 페이지 존재 여부' })
   hasNextData: boolean;
@@ -22,18 +10,10 @@ export class CursorPageMetaResponseDto {
 }
 
 export class CursorPageResponseDto<T> {
-  @ApiProperty({
-    description: '데이터 목록',
-    type: 'array',
-    items: {
-      oneOf: [
-        { $ref: getSchemaPath(GetNoticeResponseDto) },
-        { $ref: getSchemaPath(PostPreview) },
-        { $ref: getSchemaPath(PostPreviewWithBoardName) },
-        { $ref: getSchemaPath(MyComment) },
-      ],
-    },
-  })
+  constructor(meta: CursorPageMetaResponseDto) {
+    this.meta = meta;
+  }
+
   data: T[];
 
   @ApiProperty({ description: '페이징 관련 메타데이터' })

--- a/src/community/comment/comment.service.ts
+++ b/src/community/comment/comment.service.ts
@@ -50,8 +50,7 @@ export class CommentService {
         ? (lastData.createdAt.getTime() + 1).toString().padStart(14, '0')
         : null,
     };
-    const result = new GetMyCommentListResponseDto(comments);
-    result.meta = meta;
+    const result = new GetMyCommentListResponseDto(comments, meta);
 
     return result;
   }

--- a/src/community/comment/dto/get-myComment-list.dto.ts
+++ b/src/community/comment/dto/get-myComment-list.dto.ts
@@ -1,10 +1,20 @@
-import { CursorPageResponseDto } from 'src/common/dto/CursorPageResponse.dto';
+import {
+  CursorPageMetaResponseDto,
+  CursorPageResponseDto,
+} from 'src/common/dto/CursorPageResponse.dto';
 import { MyComment } from './get-comment.dto';
 import { CommentEntity } from 'src/entities/comment.entity';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class GetMyCommentListResponseDto extends CursorPageResponseDto<MyComment> {
-  constructor(commentEntities: CommentEntity[]) {
-    super();
+  @ApiProperty({ type: [MyComment], description: '댓글 목록' })
+  data: MyComment[];
+
+  constructor(
+    commentEntities: CommentEntity[],
+    meta: CursorPageMetaResponseDto,
+  ) {
+    super(meta);
     this.data = commentEntities.map(
       (commentEntity) => new MyComment(commentEntity),
     );

--- a/src/community/post/dto/get-post-list-with-board.dto.ts
+++ b/src/community/post/dto/get-post-list-with-board.dto.ts
@@ -11,7 +11,10 @@ import {
 import { BoardEntity } from 'src/entities/board.entity';
 import { PostEntity } from 'src/entities/post.entity';
 import { CursorPageOptionsDto } from 'src/common/dto/CursorPageOptions.dto';
-import { CursorPageResponseDto } from 'src/common/dto/CursorPageResponse.dto';
+import {
+  CursorPageMetaResponseDto,
+  CursorPageResponseDto,
+} from 'src/common/dto/CursorPageResponse.dto';
 import { PostPreview } from './post-preview.dto';
 
 class BoardInfo {
@@ -32,20 +35,23 @@ class BoardInfo {
 }
 
 export class GetPostListWithBoardResponseDto extends CursorPageResponseDto<PostPreview> {
+  @ApiProperty({ description: '게시판 정보' })
+  board: BoardInfo;
+
+  @ApiProperty({ type: [PostPreview], description: '게시글 목록' })
+  data: PostPreview[];
   constructor(
     boardEntity: BoardEntity,
     postEntities: PostEntity[],
     userId: number,
+    meta: CursorPageMetaResponseDto,
   ) {
-    super();
+    super(meta);
     this.board = new BoardInfo(boardEntity);
     this.data = postEntities.map(
       (postEntity) => new PostPreview(postEntity, userId),
     );
   }
-
-  @ApiProperty({ description: '게시판 정보' })
-  board: BoardInfo;
 }
 
 export class GetPostListWithBoardRequestDto extends CursorPageOptionsDto {

--- a/src/community/post/dto/get-post-list.dto.ts
+++ b/src/community/post/dto/get-post-list.dto.ts
@@ -2,12 +2,22 @@ import { PostEntity } from 'src/entities/post.entity';
 import { ApiProperty } from '@nestjs/swagger';
 import { CursorPageOptionsDto } from 'src/common/dto/CursorPageOptions.dto';
 import { IsOptional, IsString, MinLength } from 'class-validator';
-import { CursorPageResponseDto } from 'src/common/dto/CursorPageResponse.dto';
+import {
+  CursorPageMetaResponseDto,
+  CursorPageResponseDto,
+} from 'src/common/dto/CursorPageResponse.dto';
 import { PostPreviewWithBoardName } from './post-preview.dto';
 
 export class GetPostListResponseDto extends CursorPageResponseDto<PostPreviewWithBoardName> {
-  constructor(postEntities: PostEntity[], userId: number) {
-    super();
+  @ApiProperty({ type: [PostPreviewWithBoardName], description: '게시글 목록' })
+  data: PostPreviewWithBoardName[];
+
+  constructor(
+    postEntities: PostEntity[],
+    userId: number,
+    meta: CursorPageMetaResponseDto,
+  ) {
+    super(meta);
     this.data = postEntities.map(
       (postEntity) => new PostPreviewWithBoardName(postEntity, userId),
     );

--- a/src/community/post/post.service.ts
+++ b/src/community/post/post.service.ts
@@ -81,8 +81,12 @@ export class PostService {
         ? (lastData.createdAt.getTime() + 1).toString().padStart(14, '0')
         : null,
     };
-    const result = new GetPostListWithBoardResponseDto(board, posts, user.id);
-    result.meta = meta;
+    const result = new GetPostListWithBoardResponseDto(
+      board,
+      posts,
+      user.id,
+      meta,
+    );
     this.makeThumbnailDirUrlInPostList(result.data);
 
     return result;
@@ -375,8 +379,7 @@ export class PostService {
         ? (lastData.createdAt.getTime() + 1).toString().padStart(14, '0')
         : null,
     };
-    const result = new GetPostListResponseDto(posts, user.id);
-    result.meta = meta;
+    const result = new GetPostListResponseDto(posts, user.id, meta);
     this.makeThumbnailDirUrlInPostList(result.data);
 
     return result;
@@ -403,8 +406,7 @@ export class PostService {
         ? (lastData.createdAt.getTime() + 1).toString().padStart(14, '0')
         : null,
     };
-    const result = new GetPostListResponseDto(posts, user.id);
-    result.meta = meta;
+    const result = new GetPostListResponseDto(posts, user.id, meta);
     this.makeThumbnailDirUrlInPostList(result.data);
 
     return result;
@@ -429,8 +431,7 @@ export class PostService {
         ? (lastData.createdAt.getTime() + 1).toString().padStart(14, '0')
         : null,
     };
-    const result = new GetPostListResponseDto(posts, user.id);
-    result.meta = meta;
+    const result = new GetPostListResponseDto(posts, user.id, meta);
     this.makeThumbnailDirUrlInPostList(result.data);
 
     return result;
@@ -460,8 +461,7 @@ export class PostService {
         ? (lastData.createdAt.getTime() + 1).toString().padStart(14, '0')
         : null,
     };
-    const result = new GetPostListResponseDto(posts, user.id);
-    result.meta = meta;
+    const result = new GetPostListResponseDto(posts, user.id, meta);
     this.makeThumbnailDirUrlInPostList(result.data);
 
     return result;
@@ -492,8 +492,7 @@ export class PostService {
         ? (lastData.createdAt.getTime() + 1).toString().padStart(14, '0')
         : null,
     };
-    const result = new GetPostListResponseDto(posts, user.id);
-    result.meta = meta;
+    const result = new GetPostListResponseDto(posts, user.id, meta);
     this.makeThumbnailDirUrlInPostList(result.data);
 
     return result;

--- a/src/decorators/docs/notice.decorator.ts
+++ b/src/decorators/docs/notice.decorator.ts
@@ -1,5 +1,4 @@
 import { ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { CursorPageResponseDto } from 'src/common/dto/CursorPageResponse.dto';
 import { MethodNames } from 'src/common/types/method';
 import { GetNoticeResponseDto } from 'src/notice/dto/get-notice.dto';
 import { NoticeController } from 'src/notice/notice.controller';
@@ -29,7 +28,7 @@ const NoticeDocsMap: Record<NoticeEndPoints, MethodDecorator[]> = {
     ApiResponse({
       status: 200,
       description: '알림 조회 성공',
-      type: CursorPageResponseDto<GetNoticeResponseDto>,
+      type: GetNoticeResponseDto,
     }),
   ],
 };

--- a/src/notice/dto/get-notice.dto.ts
+++ b/src/notice/dto/get-notice.dto.ts
@@ -1,8 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { NoticeEntity } from 'src/entities/notice.entity';
 import { Notice } from '../enum/notice.enum';
+import {
+  CursorPageMetaResponseDto,
+  CursorPageResponseDto,
+} from 'src/common/dto/CursorPageResponse.dto';
 
-export class GetNoticeResponseDto {
+export class NoticeDto {
   constructor(noticeEntity: NoticeEntity) {
     this.id = noticeEntity.id;
     this.content = noticeEntity.content;
@@ -31,4 +35,16 @@ export class GetNoticeResponseDto {
 
   @ApiProperty({ description: '연결 핸들러' })
   handler?: number;
+}
+
+export class GetNoticeResponseDto extends CursorPageResponseDto<NoticeDto> {
+  @ApiProperty({ type: [NoticeDto], description: '알림 목록' })
+  data: NoticeDto[];
+
+  constructor(noticeEntities: NoticeEntity[], meta: CursorPageMetaResponseDto) {
+    super(meta);
+    this.data = noticeEntities.map(
+      (noticeEntity) => new NoticeDto(noticeEntity),
+    );
+  }
 }

--- a/src/notice/notice.controller.ts
+++ b/src/notice/notice.controller.ts
@@ -7,7 +7,6 @@ import { User } from 'src/decorators/user.decorator';
 import { AuthorizedUserDto } from 'src/auth/dto/authorized-user-dto';
 import { GetNoticeResponseDto } from './dto/get-notice.dto';
 import { CursorPageOptionsDto } from 'src/common/dto/CursorPageOptions.dto';
-import { CursorPageResponseDto } from 'src/common/dto/CursorPageResponse.dto';
 import { NoticeDocs } from 'src/decorators/docs/notice.decorator';
 
 @Controller('notice')
@@ -33,7 +32,7 @@ export class NoticeController {
   async getNotices(
     @User() user: AuthorizedUserDto,
     @Query() pageOption: CursorPageOptionsDto,
-  ): Promise<CursorPageResponseDto<GetNoticeResponseDto>> {
+  ): Promise<GetNoticeResponseDto> {
     return await this.noticeService.getNotices(user, pageOption);
   }
 }

--- a/src/notice/notice.service.ts
+++ b/src/notice/notice.service.ts
@@ -7,10 +7,7 @@ import { EntityManager, LessThanOrEqual, Repository } from 'typeorm';
 import { GetNoticeResponseDto } from './dto/get-notice.dto';
 import { Notice } from './enum/notice.enum';
 import { CursorPageOptionsDto } from 'src/common/dto/CursorPageOptions.dto';
-import {
-  CursorPageMetaResponseDto,
-  CursorPageResponseDto,
-} from 'src/common/dto/CursorPageResponse.dto';
+import { CursorPageMetaResponseDto } from 'src/common/dto/CursorPageResponse.dto';
 
 interface user {
   userId: number;
@@ -63,7 +60,7 @@ export class NoticeService {
   async getNotices(
     user: AuthorizedUserDto,
     pageOption: CursorPageOptionsDto,
-  ): Promise<CursorPageResponseDto<GetNoticeResponseDto>> {
+  ): Promise<GetNoticeResponseDto> {
     const cursor = new Date('9999-12-31');
     if (pageOption.cursor) {
       cursor.setTime(Number(pageOption.cursor));
@@ -88,10 +85,7 @@ export class NoticeService {
         ? (lastData.createdAt.getTime() + 1).toString().padStart(14, '0')
         : null,
     };
-    const result: CursorPageResponseDto<GetNoticeResponseDto> = {
-      data: notices.map((notice) => new GetNoticeResponseDto(notice)),
-      meta: meta,
-    };
+    const result = new GetNoticeResponseDto(notices, meta);
 
     await this.noticeRepository.update({ userId: user.id }, { isNew: false });
 


### PR DESCRIPTION
## 📝 Description
swagger 문서를 살짝 수정했습니다
커서기반 페이지네이션 적용된 응답Dto를 공통으로 사용했는데 여기다가 oneOf로 가능한 제너럴타입들을 모두 넣었던 게 보기 안좋아서
상속받은 Dto에서 ApiProperty를 직접 할당하도록 수정하였습니다.


## 🧪 Test
잘 바껴서 나오는지
meta데이터 할당의 로직을 아주 살짝 수정했는데 데이터도 잘 반환되는지 확인해주시면 감사하겠습니다.

