### PR TITLE
hotfix/id-extractor

### DIFF
--- a/src/utils/user-id-extractor.util.ts
+++ b/src/utils/user-id-extractor.util.ts
@@ -4,7 +4,10 @@ export function extractUserId(request: any): string {
   // 로그인한 사용자의 경우 - userId 바로 추출
   if (request.user) {
     userId = request.user.id;
-  } else if (request.headers['authorization'].split(' ')[0] === 'Bearer') {
+  } else if (
+    request.headers['authorization'] &&
+    request.headers['authorization'].split(' ')[0] === 'Bearer'
+  ) {
     // 토큰은 있지만, 만료된 경우 - 토큰에서 userId 추출
     const splitedTokens = request.headers['authorization']
       .split(' ')[1]


### PR DESCRIPTION
- 기존에는 로그인하지 않은 사용자의 경우 바로 header부분의 authorization에 접근해서 split 메서드를 실행함
- authorization이 null 일때 호출되어 에러 발생하는 문제를 다음과 같이 변경하여 해결

## 📝 Description
- 로그인하지 않은 유저는 토큰이 존재하지 않아서 header 부분의 authorization이 존재하지 않았음
- 존재하지 않은 상태에서 split메서드를 호출하여 에러가 발생하는 상황을 먼저 authorization이 존재하는지 확인하고 추출하는 방식으로 수정

## 🧪 Test
이제 로그인하지 않은 사용자가 요청을 보냈을 때 에러가 나지않고 잘 동작하는지 체크해주시면 감사하겠습니다.