### PR TITLE
feat:: 강의 검색 시 인덱싱, 테스트용 엔드포인트 추가

### DIFF
--- a/src/course/course.controller.ts
+++ b/src/course/course.controller.ts
@@ -11,12 +11,29 @@ import { CourseDocs } from 'src/decorators/docs/course.decorator';
 import { GetGeneralCourseDto } from './dto/get-general-course.dto';
 import { GetMajorCourseDto } from './dto/get-major-course.dto';
 import { GetAcademicFoundationCourseDto } from './dto/get-academic-foundation-course.dto';
+import { CourseEntity } from 'src/entities/course.entity';
 
 @ApiTags('course')
 @CourseDocs
 @Controller('course')
 export class CourseController {
   constructor(private courseService: CourseService) {}
+
+  // test1 - LIKE 사용
+  @Get('get-all-course/:keyword')
+  async getAllCourse(
+    @Param('keyword') keyword: string,
+  ): Promise<CourseEntity[]> {
+    return await this.courseService.getAllCourse(keyword);
+  }
+
+  // test2 - full text search 사용
+  @Get('get-all-course-index/:keyword')
+  async getAllCourseIndex(
+    @Param('keyword') keyword: string,
+  ): Promise<CourseEntity[]> {
+    return await this.courseService.getAllCourseIndex(keyword);
+  }
 
   // 학수번호 검색
   @UseGuards(JwtAuthGuard)

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -21,6 +21,39 @@ export class CourseService {
     private courseDetailRepository: CourseDetailRepository,
   ) {}
 
+  // test 1
+  async getAllCourse(keyword): Promise<CourseEntity[]> {
+    const courses = await this.courseRepository
+      .createQueryBuilder('course')
+      .leftJoinAndSelect('course.courseDetails', 'courseDetails')
+      .where('course.courseName LIKE :keyword', { keyword: `%${keyword}%` })
+      .orWhere('course.professorName LIKE :keyword', {
+        keyword: `%${keyword}%`,
+      })
+      .orWhere('course.courseCode LIKE :keyword', { keyword: `%${keyword}%` })
+      .getMany();
+
+    console.log(courses.length);
+    return courses;
+  }
+
+  // test 2
+  async getAllCourseIndex(keyword): Promise<CourseEntity[]> {
+    const courses = await this.courseRepository
+      .createQueryBuilder('course')
+      .leftJoinAndSelect('course.courseDetails', 'courseDetails')
+      .where(
+        'MATCH(course.courseName, course.professorName, course.courseCode) AGAINST (:keyword IN BOOLEAN MODE)',
+        {
+          keyword,
+        },
+      )
+      .getMany();
+
+    console.log(courses.length);
+    return courses;
+  }
+
   async getCourse(courseId: number): Promise<CommonCourseResponseDto> {
     const course = await this.courseRepository.findOne({
       where: { id: courseId },

--- a/src/decorators/docs/course.decorator.ts
+++ b/src/decorators/docs/course.decorator.ts
@@ -14,6 +14,8 @@ import { ApiKukeyExceptionResponse } from '../api-kukey-exception-response';
 type CourseEndPoints = MethodNames<CourseController>;
 
 const CourseDocsMap: Record<CourseEndPoints, MethodDecorator[]> = {
+  getAllCourseIndex: [],
+  getAllCourse: [],
   searchCourseCode: [
     ApiBearerAuth('accessToken'),
     ApiOperation({

--- a/src/entities/course.entity.ts
+++ b/src/entities/course.entity.ts
@@ -1,9 +1,19 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  Index,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { CommonEntity } from './common.entity';
 import { CourseDetailEntity } from './course-detail.entity';
 import { TimetableCourseEntity } from './timetable-course.entity';
 
 @Entity('course')
+@Index('ngram_index', ['courseName', 'professorName', 'courseCode'], {
+  fulltext: true,
+  parser: 'ngram',
+})
 export class CourseEntity extends CommonEntity {
   @PrimaryGeneratedColumn({ type: 'bigint' })
   id: number;


### PR DESCRIPTION
## 📝 Description
course table의 courseName, professorName, courseCode에 대해 full text index를 달아보았습니다. 따로 mysql에서 실행해줘야하는 쿼리는 다음과 같습니다.

1. my.cnf에 토큰 사이즈, 불용어 비활성화 설정 추가
```
ngram_token_size = 3
innodb_ft_enable_stopword = 0
```
2. mysql 서버 재실행
```
mysql.server restart (MAC 기준)

혹은 workbench에서 조작
```
3. index 생성
```
CREATE FULLTEXT INDEX ngram_index ON course(courseName, professorName, courseCode) WITH PARSER ngram;
```
4. 인덱스 메타데이터 접근을 위한 설정
```
SET GLOBAL innodb_ft_aux_table="kukey/course";
```
5. token이 잘 생성되었는지 확인 (3-gram)
```
SELECT word, doc_count, doc_id, position  FROM INFORMATION_SCHEMA.INNODB_FT_INDEX_TABLE;
```

이후 테스트용으로 만들어둔 2개의 엔드포인트를 postman, datagrip 등으로 실행해서 소요되는 시간을 확인해보면 될 것 같습니다.

## ✨ To Discuss
사실 개인적인 생각이지만 현재 데이터 개수가 2-3000개 정도로 많지 않아서 인덱싱의 필요성이 그리 크지 않을 것 같긴 합니다. 향후 실제 배포 후 커뮤니티 게시글이 많아졌을 때 커뮤니티 쪽에 적용해보는 것도 좋을 것 같습니다.

## 🧪 Test
쿼리 실행 시간 유의미하게 줄어드는지 확인해주세요.

## 🎸 ETC
```
EXPLAIN ANALYZE SELECT * FROM course INNER JOIN course_detail ON course.id = course_detail.courseId WHERE courseName LIKE '%eng%' OR professorName LIKE '%eng%' OR courseCode LIKE '%eng%';

EXPLAIN ANALYZE SELECT * FROM course INNER JOIN course_detail ON course.id = course_detail.courseId WHERE MATCH(courseName, professorName, courseCode) AGAINST ('eng' IN BOOLEAN MODE);
```
이 쿼리 2개를 실행해보았을 때
```
-> Nested loop inner join  (cost=573 rows=1017) (actual time=0.0922..11.5 rows=1251 loops=1)

-> Nested loop inner join  (cost=0.972 rows=1.78) (actual time=0.216..7.82 rows=1251 loops=1)
```
실행 시간이 약간 줄어드는 것은 확인할 수 있었습니다.

